### PR TITLE
Visual: change public functions to camel case and set `/criar-changelog` loading message as ephemeral.

### DIFF
--- a/Sources/Bot.ts
+++ b/Sources/Bot.ts
@@ -1,7 +1,9 @@
 import { Client, REST, Routes } from "discord.js";
 import { Logger } from "tslog";
 import Commands from "./Commands";
-import HandleCommand from "./Handlers/Command";
+import setupHandlersFor from "./Handlers";
+import handleCommand from "./Handlers/Command";
+
 export default class Codify {
   rest: REST;
   client: Client;
@@ -31,13 +33,7 @@ export default class Codify {
         body: this.commands.map((command) => command.data.toJSON()),
       }
     );
-    this.logger.debug(`Refreshed ${Commands.length} application (/) commands.`);
-  }
-
-  setupHandlers() {
-    this.client.on("interactionCreate", (interaction) => {
-      HandleCommand(this, interaction);
-    });
+    this.logger.info(`Refreshed ${Commands.length} application (/) commands.`);
   }
 
   async start() {
@@ -45,9 +41,9 @@ export default class Codify {
     await this.prepareCommands();
 
     this.logger.debug("Loading handlers...");
-    this.setupHandlers();
+    setupHandlersFor(this);
 
-    this.logger.info("Logging into discord...");
+    this.logger.debug("Logging into discord...");
     await this.client.login(this.token);
   }
 }

--- a/Sources/Commands/Slash/Moderation/Changelog.ts
+++ b/Sources/Commands/Slash/Moderation/Changelog.ts
@@ -7,8 +7,8 @@ import {
   ActionRowBuilder,
   EmbedBuilder,
 } from "discord.js";
-import { GenerateInteractionID } from "../../../Utils/ID";
-import { CodeBlock } from "../../../Utils/Markdown";
+import { generateInteractionID } from "../../../Utils/ID";
+import { codeBlock } from "../../../Utils/Markdown";
 import Command, { Context } from "../../Command";
 
 export default class ChangelogCommand extends Command {
@@ -25,7 +25,7 @@ export default class ChangelogCommand extends Command {
 
   async execute({ codify, interaction }: Context) {
     const modal = new ModalBuilder()
-      .setCustomId(GenerateInteractionID(interaction))
+      .setCustomId(generateInteractionID(interaction))
       .setTitle("Criar nova lista de alteração");
 
     const changelogInput = new TextInputBuilder()
@@ -69,7 +69,7 @@ export default class ChangelogCommand extends Command {
       if (changelogChannel?.isTextBased()) {
         const embed = new EmbedBuilder()
           .setDescription(
-            `> ⚠️ Mudanças feitas em ${new Date().toTimeString()}\n${CodeBlock(
+            `> ⚠️ Mudanças feitas em ${new Date().toTimeString()}\n${codeBlock(
               "diff",
               changelog
             )}`

--- a/Sources/Commands/Slash/Moderation/Changelog.ts
+++ b/Sources/Commands/Slash/Moderation/Changelog.ts
@@ -53,7 +53,7 @@ export default class ChangelogCommand extends Command {
 
     if (submit) {
       const changelog = submit.fields.getTextInputValue("changelog");
-      await submit.deferReply();
+      await submit.deferReply({ ephemeral: true });
       await submit.followUp(`:stopwatch: Enviando changelog...`);
       const changelogChannelId = interaction.options.getChannel("canal")?.id;
 

--- a/Sources/Handlers/Command.ts
+++ b/Sources/Handlers/Command.ts
@@ -3,7 +3,7 @@ import { Logger } from "tslog";
 import Codify from "../Bot";
 import { Context } from "../Commands/Command";
 
-export default async function HandleCommand(
+export default async function handleCommand(
   codify: Codify,
   interaction: Interaction
 ) {

--- a/Sources/Handlers/index.ts
+++ b/Sources/Handlers/index.ts
@@ -1,0 +1,15 @@
+import { Logger } from "tslog";
+import Codify from "../Bot";
+import handleCommand from "./Command";
+
+export default function setupHandlersFor(codify: Codify) {
+  const logger = new Logger();
+
+  codify.client.on("interactionCreate", (interaction) => {
+    handleCommand(codify, interaction);
+  });
+
+  codify.client.on("ready", (me) => {
+    logger.info(`${me.user.tag} is ready!`);
+  });
+}

--- a/Sources/Main.ts
+++ b/Sources/Main.ts
@@ -8,4 +8,5 @@ const codify = new Codify(
   process.env.DISCORD_CLIENT_ID,
   process.env.DISCORD_GUILD_ID
 );
+
 codify.start();

--- a/Sources/Utils/ID.ts
+++ b/Sources/Utils/ID.ts
@@ -1,5 +1,8 @@
 import { ChatInputCommandInteraction } from "discord.js";
+import { Logger } from "tslog";
+
 let counter = 0;
+const logger = new Logger();
 
 /**
  * Generates a interaction ID for any item that requires a ID.
@@ -7,12 +10,15 @@ let counter = 0;
  * @param interaction Interaction to generate a ID
  * @returns {string}
  */
-export function GenerateInteractionID(
+export function generateInteractionID(
   interaction: ChatInputCommandInteraction
 ): string {
   if (counter >= 10000) {
     counter = 0;
+    logger.info(`interactionID counter has been reseted to zero (0)!`);
   }
+
+  logger.silly(`Generated new interactionID: ${counter}`);
   const text = `${interaction.commandName}-${counter}`;
   counter++;
 

--- a/Sources/Utils/Markdown.ts
+++ b/Sources/Utils/Markdown.ts
@@ -1,3 +1,3 @@
-export function CodeBlock(lang: string, code: string): string {
+export function codeBlock(lang: string, code: string): string {
   return `\`\`\`${lang}\n${code}\`\`\``;
 }


### PR DESCRIPTION
And improve logging.